### PR TITLE
Update MqttOwfs.cpp

### DIFF
--- a/src/MqttOwfs.cpp
+++ b/src/MqttOwfs.cpp
@@ -234,7 +234,7 @@ string MqttOwfs::OwGetValue(const string& configName, int round, bool uncachedRe
 
     try
     {
-		m_OwfsClient.SetOwserverFlag(owfscpp::Uncached, uncachedRead);
+        m_OwfsClient.SetOwserverFlag(owfscpp::Uncached, uncachedRead);
         svalue = m_OwfsClient.Get(configName);
     }
     catch (const exception& e)
@@ -306,34 +306,37 @@ void MqttOwfs::OwDeviceAdd(const string& name)
     switch(family)
     {
 		case 0x01 : 	//DS2401
-		    OwDeviceAdd(name, name+"/IsPresent", -1);
+		    OwDeviceAdd(name+"/IsPresent", name+"/IsPresent", -1);
 			break;
 		case 0x05 : 	//DS2405
 		    OwDeviceAdd(name, name+"/PIO", -1);
 			break;
 		case 0x10 :		//DS18S20, DS1920
-		    OwDeviceAdd(name, name+"/temperature9", 1);
+		    OwDeviceAdd(name+"/temperature", name+"/temperature", -1);
 			break;
 		case 0x12 :		//DS2406/07
 		    OwDeviceAdd(name, name+"/PIO.A", -1);
 			break;
 		case 0x1D :		//DS2423
-		    OwDeviceAdd(name, name+"/counters.A", -1);
+		    OwDeviceAdd(name+"/counters.A", name+"/counters.A", -1);
+		    OwDeviceAdd(name+"/counters.B", name+"/counters.B", -1);
 			break;
 		case 0x20 : 	//DS2450
 		    OwDeviceAdd(name, name+"/PIO.A", -1);
 			break;
 		case 0x21 :		//DS1921
-		    OwDeviceAdd(name, name+"/temperature9", 1);
+		    OwDeviceAdd(name+"/temperature", name+"/temperature", -1);
 			break;
 		case 0x22 :		//DS1822
-		    OwDeviceAdd(name, name+"/temperature9", 1);
+		    OwDeviceAdd(name+"/temperature", name+"/temperature", -1);
 			break;
 		case 0x26 :		//DS2438
-		    OwDeviceAdd(name, name+"/VDD", 1);
+		    OwDeviceAdd(name+"/VDD", name+"/VDD", -1);
+		    OwDeviceAdd(name+"/humidity", name+"/humidity", -1);
+		    OwDeviceAdd(name+"/temperature", name+"/temperature", -1);
 			break;
 		case 0x28 : 	//DS18B20
-		    OwDeviceAdd(name, name+"/temperature9", 1);
+		    OwDeviceAdd(name+"/temperature", name+"/temperature", -1);
 			break;
 		case 0x29 : 	//DS2408
 		    OwDeviceAdd(name, name+"/PIO.BYTE", -1);


### PR DESCRIPTION

<img width="1020" alt="Screenshot 2020-12-31 at 01 02 32" src="https://user-images.githubusercontent.com/6303627/103387423-fefe5d00-4b03-11eb-92ce-d1041862244e.png">
changed temperature9 to temperature for the finer resolution on onewire devices
changed 1 to -1
add the name of the item to the prefix - so it can be used in Grafana via mqtt -> db bridge
added counter.B (because there are 2 counters)
added for DS2438 : humidity / temperature in addition to VDD (because these are commonly used to monitor server rooms)

This gives me :
root@xxxx:/tmp# mosquitto_sub -u userx -P userx -v -t 'owfs/#'
owfs/01.7C17A6180000/IsPresent 1
owfs/10.1714E6010800/temperature 19.5
owfs/28.201A8D020000/temperature 6.25
owfs/28.02FF8C020000/temperature 22.9375
owfs/28.62308D020000/temperature 11.5625
owfs/28.FA128D020000/temperature 20.125
owfs/28.89038D020000/temperature 24.1875
owfs/28.B9EE8C020000/temperature 12.125
owfs/28.F9398D020000/temperature 18.8125
owfs/28.451B8D020000/temperature 7.1875
owfs/28.752F8D020000/temperature 19.25
owfs/28.AD1A8D020000/temperature 9.4375
owfs/28.831A8D020000/temperature 11.9375
owfs/28.CBEF8C020000/temperature 21.375
owfs/28.5F228D020000/temperature 17.8125
owfs/28.FFA98BC21604/temperature 16
owfs/26.90C6F1000000/humidity 46.5603
owfs/26.90C6F1000000/temperature 20.3438
owfs/1D.48710E000000/counters.A 19239648
owfs/1D.48710E000000/counters.B 101392572
owfs/1D.14830E000000/counters.A 3631855
owfs/1D.14830E000000/counters.B 416
owfs/1D.DA4C0F000000/counters.A 48654763
owfs/1D.DA4C0F000000/counters.B 58992308
owfs/1D.D74C0F000000/counters.A 97026433
owfs/1D.D74C0F000000/counters.B 143281502
owfs/1D.5FC70F000000/counters.A 35512355
owfs/1D.5FC70F000000/counters.B 112281
owfs/1D.D74C0F000000/counters.B 143281506
owfs/26.90C6F1000000/temperature 20.4375
owfs/28.752F8D020000/temperature 19.1875
owfs/28.831A8D020000/temperature 11.875
owfs/1D.D74C0F000000/counters.A 97026436
owfs/26.90C6F1000000/humidity 46.5696